### PR TITLE
Check the correct file exists

### DIFF
--- a/setup
+++ b/setup
@@ -50,7 +50,7 @@ if [ ! -d "$HOME/.bin/" ]; then
   mkdir "$HOME/.bin"
 fi
 
-if [ ! -f "$HOME/.bashhrc" ]; then
+if [ ! -f "$HOME/.bashrc" ]; then
   touch "$HOME/.bashrc"
 fi
 


### PR DESCRIPTION
`.bashrc` will always be touched (unless `.bashhrc` actually exists).  Unlikely to be a big deal most of the time, but it will update the file access/modification time.